### PR TITLE
Add helper functions publishDataForAnalytics() and getPublishedDataForAnalytics()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.x.x
+
+* Add helper functions publishDataForAnalytics() and getPublishedDataForAnalytics()
+
+
 ## v1.1.10
 
 * Output head tags directly after <title></title> element

--- a/helpers/analyticUtils.cfm
+++ b/helpers/analyticUtils.cfm
@@ -1,0 +1,15 @@
+<cfscript>
+public void function publishDataForAnalytics( required struct data ) {
+	var prc = getRequestContext().getCollection( private = true );
+
+	prc._analyticsData = prc._analyticsData ?: {};
+
+	StructAppend( prc._analyticsData, arguments.data );
+}
+
+public struct function getPublishedDataForAnalytics() {
+	var prc = getRequestContext().getCollection( private = true );
+
+	return prc._analyticsData ?: {};
+}
+</cfscript>


### PR DESCRIPTION
Add helper functions publishDataForAnalytics() and getPublishedDataForAnalytics() to help in gathering analytic data throughout the request